### PR TITLE
Add node engines version and heroku-postbuild to scripts section

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "frontend",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "npm": "6.14.4",
+    "node": "12.x"
+  },
   "dependencies": {
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
@@ -15,7 +19,8 @@
     "build": "react-scripts build",
     "test": "react-scripts test --watchAll=false --coverage --collectCoverageFrom=!**/serviceWorker.js",
     "coveralls": "cat ./coverage/lcov.info | node node_modules/.bin/coveralls",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "heroku-postbuild": "npm run build"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
+    "node": "12.x",
     "npm": "6.14.4",
-    "node": "12.x"
+    "yarn": "1.22.4"
   },
   "dependencies": {
     "@testing-library/jest-dom": "^4.2.4",
@@ -19,8 +20,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test --watchAll=false --coverage --collectCoverageFrom=!**/serviceWorker.js",
     "coveralls": "cat ./coverage/lcov.info | node node_modules/.bin/coveralls",
-    "eject": "react-scripts eject",
-    "heroku-postbuild": "npm run build"
+    "eject": "react-scripts eject"
   },
   "eslintConfig": {
     "extends": "react-app"


### PR DESCRIPTION
Staging branch Heroku app crashed and exited with a H10 error. Implemented some solutions which suggested adding the versions of the node engines used and a heroku-postbuild command to package-json, as well as switching from the default Heroku buildpack (heroku/nodejs) to heroku buildpacks:set mars/create-react-app through the Heroku CLI.